### PR TITLE
automatically download 3rd party jasmine dependency

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -35,6 +35,7 @@ var ts = require('gulp-typescript');
 var less = require('gulp-less');
 var minifyCSS = require('gulp-minify-css');
 var typedoc = require("gulp-typedoc");
+var download = require("gulp-download");
 var jasmineBrowser = require('gulp-jasmine-browser');
 var spritesmith = require('gulp.spritesmith');
 const tslint = require('gulp-tslint');
@@ -125,9 +126,15 @@ gulp.task('build_visuals_less', function () {
     .pipe(gulp.dest('src/Clients/PowerBIVisualsPlayground'));
 });
 
+// Download dependencies
+
+gulp.task('dependencies', function() {
+	download('https://raw.github.com/velesin/jasmine-jquery/master/lib/jasmine-jquery.js')
+    		.pipe(gulp.dest("src/Clients/Externals/ThirdPartyIP/JasmineJQuery"));
+});
 
 gulp.task('build', function() {
-	runSequence('tslint', 'build_visuals_projects', 'combine_js', 'combine_js_all_min', 'combine_dts', 'build_app', 'sprite', 'build_visuals_less');
+	runSequence('dependencies', 'tslint', 'build_visuals_projects', 'combine_js', 'combine_js_all_min', 'combine_dts', 'build_app', 'sprite', 'build_visuals_less');
 });
 
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "devDependencies": {
     "gulp": "^3.9.0",
     "gulp-concat": "^2.6.0",
+    "gulp-download": "0.0.1",
     "gulp-ignore": "^1.2.1",
     "gulp-jasmine-browser": "^0.1.4",
     "gulp-less": "^3.0.3",
@@ -24,6 +25,6 @@
     "typescript": "1.5.3"
   },
   "scripts": {
-    "preinstall": "npm install -g gulp"   
+    "preinstall": "npm install -g gulp"
   }
 }


### PR DESCRIPTION
Issue #10 shows a build error which is corrected with a manual download of a 3rd party dependency. 

This pull request introduces gulp-download and automates this process so that gulp build will ensure that the 3rd party dependency is present.