### PR TITLE
Prevent download of test asset on every build - instead only on test

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -239,7 +239,6 @@ gulp.task('dependencies', function() {
 
 gulp.task("build", function (callback) {
 	runSequence(
-		"dependencies",
 		"tslint",
 		"build_projects",
 		callback);
@@ -277,8 +276,9 @@ gulp.task("run_tests", function () {
 });
 
 gulp.task("test", function (callback) {
-	runSequence(
+    runSequence(
 		"build",
+		"dependencies",
 		"copy_dependencies_visuals_tests", 
 		"run_tests", 
 		callback);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,6 +43,7 @@ var git = require('gulp-git');
 var run = require('gulp-run');
 var tslint = require('gulp-tslint');
 var download = require("gulp-download");
+var fs = require("fs");
 
 var jsUglifyOptions = {
     compress: {
@@ -232,9 +233,17 @@ gulp.task("build_projects", function (callback) {
 });
 
 /** Download dependencies */
-gulp.task('dependencies', function() {
-	download('https://raw.github.com/velesin/jasmine-jquery/master/lib/jasmine-jquery.js')
-    		.pipe(gulp.dest("src/Clients/Externals/ThirdPartyIP/JasmineJQuery"));
+gulp.task('dependencies', function () {
+    fs.exists('src/Clients/Externals/ThirdPartyIP/JasmineJQuery/jasmine-jquery.js', function (exists) {
+        if (!exists) {
+            console.log('Jasmine test dependency missing. Downloading dependency.');
+            download('https://raw.github.com/velesin/jasmine-jquery/master/lib/jasmine-jquery.js')
+                .pipe(gulp.dest("src/Clients/Externals/ThirdPartyIP/JasmineJQuery"));
+        }
+        else {
+            console.log('Jasmine test dependency exists.');
+        }
+    });
 });
 
 gulp.task("build", function (callback) {


### PR DESCRIPTION
We made a change to remove a manual download step of jasmine; however this was plugged into the gulp 'build' task, meaning it downloads the asset on every build. This is usually ok, but on a slower network connection it's noticeable as the gulp build pauses for a while as the file is downloaded.

This PR moves the download dependencies task into a subtask of the 'test' task so only when you invoke 'gulp test' does the file get downloaded.