### PR TITLE
Add AppVeyor CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,52 @@
+# Power BI Visualizations
+
+# Copyright (c) Microsoft Corporation
+# All rights reserved. 
+# MIT License
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the ""Software""), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in 
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR 
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, 
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE 
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER 
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+# appveyor CI configuration file
+# http://www.appveyor.com/docs/appveyor-yml
+
+os: Windows Server 2012
+
+# build platform, i.e. x86, x64, Any CPU. This setting is optional.
+platform: Any CPU
+
+# build cache to preserve files/folders between builds
+cache:
+  - node_modules # local npm modules
+
+# scripts that run after cloning repository
+install:
+  - npm install
+
+build_script:
+  - gulp build
+
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
+test_script:
+  - gulp jasmine-dependency
+  - gulp phantomjs-dependency
+  - gulp copy_dependencies_visuals_tests
+  - gulp run_tests

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "gulp-uglifyjs": "^0.6.2",
     "gulp-util": "^3.0.6",
     "gulp.spritesmith": "^4.0.0",
+    "gulp-unzip": "^0.1.3",
     "merge2": "^0.3.6",
     "run-sequence": "^1.1.2",
     "tslint": "2.4.2",


### PR DESCRIPTION
Add support AppVeyor CI:
* adds appveyor.yml - config file for AppVeyor CI. (http://www.appveyor.com/docs/appveyor-yml) 
* adds new task 'phantomjs-dependency' to gulpfile.js in order to download 'Phantomjs';
* adds dependency 'gulp-unzip' to package.json;