### PR TITLE
Added ability to debug tests.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,4 +1,3 @@
-/// <binding BeforeBuild='build' />
 /*
  *  Power BI Visualizations
  *
@@ -45,8 +44,39 @@ var tslint = require('gulp-tslint');
 var download = require("gulp-download");
 var unzip = require("gulp-unzip");
 var fs = require("fs");
+var minimist = require("minimist");
 var os = require("os");
 var exec = require('child_process').exec;
+var open = require("gulp-open");
+
+var isDebug = false;
+
+var cliOptions = {
+    string: [
+        "files",
+        "openInBrowser"
+    ],
+    boolean: "debug",
+    alias: {
+        files: "f",
+        debug: "d",
+        openInBrowser: ["o", "oib"]
+    }
+};
+
+var cliArguments = minimist(process.argv.slice(2), cliOptions);
+
+isDebug = Boolean(cliArguments.debug);
+
+function getOptionFromCli(cliArg) {
+    if (cliArg && cliArg.length > 0) {
+        return cliArg.split(/[,;]/);
+    }
+    
+    return [];
+}
+
+var filesOption = getOptionFromCli(cliArguments.files);
 
 var jsUglifyOptions = {
     compress: {
@@ -75,6 +105,19 @@ var jsUglifyOptions = {
     }
 };
 
+function getPathsForVisualsTests(paths) {
+    var includePaths = [];
+    
+    if (paths && paths.length > 0) {
+        includePaths.push("_references.ts");
+        includePaths = includePaths.concat(paths.map(function(path) {
+            return "visuals/" + path;
+        }));
+    }
+    
+    return includePaths;
+}
+
 gulp.task("tslint", function(){
     return gulp.src([
         "src/Clients/VisualsCommon/**/*.ts",
@@ -101,14 +144,27 @@ gulp.task("tslint", function(){
         .pipe(tslint.report("verbose"));
 });
 
-function buildProject(projectPath, outFileName) {
+function buildProject(projectPath, outFileName, includePaths) {
     var paths = [
-        projectPath + "/**/*.ts",
         "!" + projectPath + "/obj/**",
         "!" + projectPath + "/**/*.d.ts"
     ];
-
-    var tscReluts = gulp.src(paths)
+    
+    if (includePaths && includePaths.length > 0) {
+        paths = paths.concat(includePaths.map(function (path) {
+            return projectPath + "/" + path;
+        }));
+    } else {
+        paths.push(projectPath + "/**/*.ts");
+    }
+    
+    var srcResult = gulp.src(paths);
+    
+    if (isDebug) {
+        srcResult = srcResult.pipe(sourcemaps.init());
+    }
+    
+    var tscResult = srcResult
         .pipe(ts({
             sortOutput: true,
             target: "ES5",
@@ -116,10 +172,14 @@ function buildProject(projectPath, outFileName) {
             out: projectPath + "/obj/" + outFileName + ".js"
         }));
 
+    if (isDebug) {
+        tscResult.js = tscResult.js.pipe(sourcemaps.write());
+    }
+
     return merge([
-        tscReluts.js.pipe(gulp.dest("./")),
-        tscReluts.dts.pipe(gulp.dest("./")),
-        tscReluts.js
+        tscResult.js.pipe(gulp.dest("./")),
+        tscResult.dts.pipe(gulp.dest("./")),
+        tscResult.js
             .pipe(uglify(outFileName + ".min.js", jsUglifyOptions))
             .pipe(gulp.dest(projectPath + "/obj"))
     ]);
@@ -143,11 +203,15 @@ gulp.task("build_visuals_sprite", function () {
 });
 
 gulp.task("build_visuals_less", function () {
-    return gulp.src("src/Clients/Visuals/styles/visuals.less")
+    var css = gulp.src(["src/Clients/Visuals/styles/visuals.less"])
         .pipe(less())
-        .pipe(minifyCSS())
-        .pipe(rename("visuals.min.css"))
-        .pipe(gulp.dest("build/styles"));
+        .pipe(concat("visuals.css"));
+
+    if (!isDebug) {
+        css = css.pipe(minifyCSS());
+    }
+    
+    return css.pipe(gulp.dest("build/styles"));
 });
 
 gulp.task("build_visuals_project", function () {
@@ -159,16 +223,39 @@ gulp.task("build_visuals", function (callback) {
 });
 
 gulp.task("build_visuals_tests", function () {
-    return buildProject("src/Clients/PowerBIVisualsTests", "PowerBIVisualsTests");
+    return buildProject(
+        "src/Clients/PowerBIVisualsTests",
+        "PowerBIVisualsTests",
+        getPathsForVisualsTests(filesOption));
 });
 
-gulp.task("copy_dependencies_visuals_playground", function () {
+gulp.task("copy_internal_dependencies_visuals_playground", function () {
+    var src = [];
+    
+    if (isDebug) {
+        src.push("src/Clients/PowerBIVisualsPlayground/obj/PowerBIVisualsPlayground.js");
+    } else {
+        src.push("src/Clients/PowerBIVisualsPlayground/obj/PowerBIVisualsPlayground.min.js");
+    }
+    
+    return gulp.src(src)
+        .pipe(rename("PowerBIVisualsPlayground.js"))
+        .pipe(gulp.dest("src/Clients/PowerBIVisualsPlayground"))
+});
+
+gulp.task("copy_external_dependencies_visuals_playground", function () {
     return gulp.src([
-        "build/scripts/powerbi-visuals.all.min.js",
-        "build/styles/visuals.min.css",
-        "src/Clients/PowerBIVisualsPlayground/obj/PowerBIVisualsPlayground.js"
+        "build/scripts/powerbi-visuals.all.js",
+        "build/styles/visuals.css"
     ])
         .pipe(gulp.dest("src/Clients/PowerBIVisualsPlayground"));
+});
+
+gulp.task("copy_dependencies_visuals_playground", function (callback) {
+    runSequence(
+        "copy_internal_dependencies_visuals_playground",
+        "copy_external_dependencies_visuals_playground",
+        callback);
 });
 
 gulp.task("build_visuals_playground_project", function () {
@@ -182,13 +269,31 @@ gulp.task("build_visuals_playground", function (callback) {
         callback);
 });
 
+function concatFilesWithSourceMap(source, outFileName) {
+    var result = source;
+    
+    if (isDebug) {
+        result = result.pipe(sourcemaps.init({loadMaps: true}));
+    }
+    
+    result = result.pipe(concat(outFileName));
+    
+    if (isDebug) {
+        result = result.pipe(sourcemaps.write());
+    }
+    
+    return result;
+}
+
 gulp.task("combine_internal_js", function () {
-    return gulp.src([
+    var srcResult = gulp.src([
         "src/Clients/VisualsCommon/obj/VisualsCommon.js",
         "src/Clients/VisualsData/obj/VisualsData.js",
         "src/Clients/Visuals/obj/Visuals.js"
-    ])
-        .pipe(concat("powerbi-visuals.js"))
+    ]);
+    
+    return concatFilesWithSourceMap(srcResult, "powerbi-visuals.js")
+        .pipe(gulp.dest("build/scripts"))
         .pipe(uglify("powerbi-visuals.min.js", jsUglifyOptions))
         .pipe(gulp.dest("build/scripts"));
 });
@@ -215,11 +320,17 @@ gulp.task("combine_external_js", function () {
 });
 
 gulp.task("combine_all", function () {
-    return gulp.src([
-        "build/scripts/externals.min.js",
-        "build/scripts/powerbi-visuals.min.js",
-    ])
-        .pipe(concat("powerbi-visuals.all.min.js"))
+    var src = [
+        "build/scripts/externals.min.js"
+    ];
+    
+    if (isDebug) {
+        src.push("build/scripts/powerbi-visuals.js");
+    } else {
+        src.push("build/scripts/powerbi-visuals.min.js");
+    }
+    
+    return concatFilesWithSourceMap(gulp.src(src), "powerbi-visuals.all.js")
         .pipe(gulp.dest("build/scripts"));
 });
 
@@ -322,31 +433,109 @@ gulp.task("build", function (callback) {
  * Tests.
  */
 
-gulp.task("copy_dependencies_visuals_tests", function () {
+gulp.task("copy_internal_dependencies_visuals_tests", function () {
+    var src = [];
+    
+    if (isDebug) {
+        src.push("src/Clients/PowerBIVisualsTests/obj/PowerBIVisualsTests.js");
+    } else {
+        src.push("src/Clients/PowerBIVisualsTests/obj/PowerBIVisualsTests.min.js");
+    }
+    
+    return gulp.src(src)
+        .pipe(rename("powerbi-visuals-tests.js"))
+        .pipe(gulp.dest("VisualsTests"));
+});
+
+gulp.task("copy_external_dependencies_visuals_tests", function () {
     return gulp.src([
-        "build/scripts/powerbi-visuals.all.min.js",
-        "src/Clients/PowerBIVisualsTests/obj/PowerBIVisualsTests.js"
+        "build/scripts/powerbi-visuals.all.js"
     ])
         .pipe(gulp.dest("VisualsTests"));
 });
 
-gulp.task("run_tests", function () {
-    return gulp.src([
-        "src/Clients/externals/ThirdPartyIP/JQuery/2.1.3/jquery.min.js",
-        "src/Clients/externals/ThirdPartyIP/D3/d3.min.js",
-        "src/Clients/externals/ThirdPartyIP/JasmineJQuery/jasmine-jquery.js",
-        "src/Clients/externals/ThirdPartyIP/LoDash/lodash.min.js",
-        "src/Clients/externals/ThirdPartyIP/GlobalizeJS/globalize.min.js",
-        "src/Clients/externals/ThirdPartyIP/MomentJS/moment.min.js",
-        "src/Clients/externals/ThirdPartyIP/Velocity/velocity.min.js",
-        "src/Clients/externals/ThirdPartyIP/Velocity/velocity.ui.min.js",
-        "src/Clients/externals/ThirdPartyIP/QuillJS/quill.min.js",
+gulp.task("copy_dependencies_visuals_tests", function (callback) {
+    runSequence(
+        "copy_internal_dependencies_visuals_tests",
+        "copy_external_dependencies_visuals_tests",
+        callback
+    );
+});
 
-        "VisualsTests/powerbi-visuals.all.min.js",
-        "VisualsTests/PowerBIVisualsTests.js"
-    ])
-        .pipe(jasmineBrowser.specRunner({console: true}))
-        .pipe(jasmineBrowser.headless());
+function addLinks(links) {
+    return (links.map(function(link) {
+        return '<link rel="stylesheet" href="' + link + '"/>';
+    })).join("");
+}
+
+function addScripts(scripts) {
+    return (scripts.map(function(script) {
+        return '<script src="' + script + '"></script>';
+    })).join("");
+}
+
+function addTestName(testName) {
+    if (testName && testName.length > 0){
+        var specName = "?spec=" + encodeURI(testName);
+        
+        return "<script>" + "if (window.location.search !=='"+ specName +"') {" +
+                "window.location.search = '" + specName + "';}</script>";
+    } else {
+        return "";
+    }
+}
+
+function createHtmlTestRunner(fileName, scripts, styles, testName) {
+    var html = "<!DOCTYPE html><html>";
+    var head = '<head><meta charset="utf-8">' + addLinks(styles) + '</head>';
+    var body = "<body>" + addScripts(scripts) + addTestName(testName) +"</body>";
+    
+    html = html + head + body + "</html>";
+    
+    fs.writeFileSync(fileName, html);
+}
+
+gulp.task("run_tests", function () {
+    var src = [
+        "powerbi-visuals.all.js",
+        
+        "../src/Clients/externals/ThirdPartyIP/JasmineJQuery/jasmine-jquery.js",
+        "../src/Clients/externals/ThirdPartyIP/MomentJS/moment.min.js",
+        "../src/Clients/externals/ThirdPartyIP/Velocity/velocity.min.js",
+        "../src/Clients/externals/ThirdPartyIP/Velocity/velocity.ui.min.js",
+        "../src/Clients/externals/ThirdPartyIP/QuillJS/quill.min.js",
+        
+        "powerbi-visuals-tests.js"
+    ];
+    
+    var scripts = [
+        "../node_modules/jasmine-core/lib/jasmine-core/jasmine.js",
+        "../node_modules/jasmine-core/lib/jasmine-core/jasmine-html.js",
+        "../node_modules/jasmine-core/lib/jasmine-core/boot.js"
+    ];
+    
+    var links = [
+        "../node_modules/jasmine-core/lib/jasmine-core/jasmine.css"
+    ];
+    
+    var specRunnerFileName = "VisualsTests/runner.html";
+    
+    var openInBrowser = cliArguments.openInBrowser;
+    
+    createHtmlTestRunner(
+        specRunnerFileName, 
+        scripts.concat(src), 
+        links,
+        getOptionFromCli(openInBrowser)[0]);
+
+    if (openInBrowser) {
+        return gulp.src(specRunnerFileName)
+            .pipe(open());
+    } else {
+        return gulp.src(src, {cwd: "VisualsTests"})
+            .pipe(jasmineBrowser.specRunner({console: true}))
+            .pipe(jasmineBrowser.headless());
+    }
 });
 
 gulp.task("test", function (callback) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,10 @@
     "merge2": "^0.3.6",
     "run-sequence": "^1.1.2",
     "tslint": "2.4.2",
-    "typescript": "1.5.3"
+    "typescript": "1.5.3",
+    "minimist": "1.1.3",
+    "jasmine-core": "2.3.4",
+    "gulp-open": "1.0.0"
   },
   "scripts": {
     "preinstall": "npm install -g gulp"

--- a/src/Clients/PowerBIVisualsPlayground/index.html
+++ b/src/Clients/PowerBIVisualsPlayground/index.html
@@ -3,9 +3,9 @@
 <head>
     <title>Power BI visualization playground</title>
     <link rel="stylesheet" href="app.css" />
-    <link rel="stylesheet" href="visuals.min.css" />
+    <link rel="stylesheet" href="visuals.css" />
     
-    <script type="text/javascript" src="powerbi-visuals.all.min.js"></script>    
+    <script type="text/javascript" src="powerbi-visuals.all.js"></script>
     <script type="text/javascript" src ="PowerBIVisualsPlayground.js"></script>
     
 </head>


### PR DESCRIPTION
Added ability to debug tests:
* CLI option "--openInBrowser" ("--o") in order to run all tests (or single test) in browser (example: "gulp test --openInBrowser" or "gulp test --o");
* CLI option "--debug" ("--d") in order to debug typescript via browser (css files are not minified) (example: "gulp build --debug" or "gulp build --d").