### PR TITLE
Allow linting to be skipped.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -53,14 +53,18 @@ require('require-dir')('./gulp');
 var expressServer = express(); 
 
 var isDebug = false,
-    openInBrowser = false;
+    openInBrowser = false,
+    noLint = false;
 
 var cliOptions = {
     string: [
         "files",
-        "openInBrowser"
     ],
-    boolean: "debug",
+    boolean: [
+        "openInBrowser",
+        "debug",
+        "noLint"
+    ],
     alias: {
         files: "f",
         debug: "d",
@@ -72,6 +76,7 @@ var cliArguments = minimist(process.argv.slice(2), cliOptions);
 
 isDebug = Boolean(cliArguments.debug);
 openInBrowser = Boolean(cliArguments.openInBrowser);
+noLint = Boolean(cliArguments.noLint);
 
 function getOptionFromCli(cliArg) {
     if (cliArg && cliArg.length > 0) {
@@ -298,6 +303,9 @@ var tslintPaths = ["src/Clients/VisualsCommon/**/*.ts",
     "!src/Clients/PowerBIVisualsPlayground/**/*.d.ts"];
 
 gulp.task("tslint", function () {
+    if (noLint)
+        return;
+
     return gulp.src(tslintPaths)
         .pipe(tslint())
         .pipe(tslint.report("verbose"));

--- a/src/Clients/PowerBIVisualsTests/visuals/treemapTests.ts
+++ b/src/Clients/PowerBIVisualsTests/visuals/treemapTests.ts
@@ -46,8 +46,6 @@ module powerbitests {
     var dataTypeNumber = ValueType.fromPrimitiveTypeAndCategory(PrimitiveType.Double);
     var dataTypeString = ValueType.fromPrimitiveTypeAndCategory(PrimitiveType.Text);
 
-    var DefaultWaitForRender = 500;
-
     powerbitests.mocks.setLocale();
 
     var dataViewMetadataCategorySeriesColumns: powerbi.DataViewMetadata = {


### PR DESCRIPTION
Add a cmdline parameter for skipping the tslint phase. This greatly speeds up the dev-test loop.
Also, fixing treemap test speed.