### PR TITLE
The operator at the beginning of `update()` must be `||` instead of `…

### DIFF
--- a/src/Clients/CustomVisuals/visuals/bulletChart/bulletChart.ts
+++ b/src/Clients/CustomVisuals/visuals/bulletChart/bulletChart.ts
@@ -587,7 +587,7 @@ module powerbi.visuals.samples {
 
         /* Called for data, size, formatting changes*/
         public update(options: VisualUpdateOptions) {
-            if (!options.dataViews && !options.dataViews[0]) return;
+            if (!options.dataViews || !options.dataViews[0]) return;
             var dataView = options.dataViews[0];
             this.viewport = options.viewport;
             this.model = BulletChart.converter(dataView, options);

--- a/src/Clients/CustomVisuals/visuals/gantt/gantt.ts
+++ b/src/Clients/CustomVisuals/visuals/gantt/gantt.ts
@@ -394,7 +394,7 @@ module powerbi.visuals.samples {
         }
 
         public update(options: VisualUpdateOptions) {
-            if (!options.dataViews && !options.dataViews[0]) {
+            if (!options.dataViews || !options.dataViews[0]) {
                 return;
             };
 

--- a/src/Clients/CustomVisuals/visuals/helloIVisual/helloIVisual.ts
+++ b/src/Clients/CustomVisuals/visuals/helloIVisual/helloIVisual.ts
@@ -114,7 +114,7 @@ module powerbi.visuals.samples {
         }
 
         public update(options: VisualUpdateOptions) {
-            if (!options.dataViews && !options.dataViews[0]) return;
+            if (!options.dataViews || !options.dataViews[0]) return;
             var dataView = this.dataView = options.dataViews[0];
             var viewport = options.viewport;
             var viewModel: HelloViewModel = HelloIVisual.converter(dataView);


### PR DESCRIPTION
At the beginning of `update()`, there is a  validation for `options.dataViews`, and the operator must be `||` instead of `&&`, otherwise, if the input is not valid, evaluating the second operand will fail with:

    Uncaught TypeError: Cannot read property '0' of undefined
