### PR TITLE
Histogram issue #2313 fixed

### DIFF
--- a/src/Clients/CustomVisuals/visuals/histogram/histogram.ts
+++ b/src/Clients/CustomVisuals/visuals/histogram/histogram.ts
@@ -252,6 +252,7 @@ module powerbi.visuals.samples {
         private NumberOfLabelsOnAxisY: number = 5;
         private MinNumberOfBins: number = 0;
         private MinPrecision: number = 0;
+        private MaxPrecision: number = 17; // max number of decimals in float
         private TooltipDisplayName: string = "Range";
         private SeparatorNumbers: string = ", ";
         private LegendSize: number = 50;
@@ -614,6 +615,10 @@ module powerbi.visuals.samples {
 
             if (precision <= this.MinPrecision) {
                 return this.MinPrecision;
+            }
+
+            if (precision >= this.MaxPrecision) {
+                return this.MaxPrecision;
             }
 
             return precision;


### PR DESCRIPTION
#2313 - Tornado Chart doesn't work, when "Decimal Points" >= 9999.