### PR TITLE
Removes field "readme" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "powerbi-visuals",
-    "version": "0.3.10",
+    "version": "0.4.0",
     "description": "Microsoft PowerBI Visuals",
     "devDependencies": {
         "fs": "0.0.2",
@@ -70,6 +70,5 @@
     "files": [
         "CONTRIBUTING.md",
         "lib"
-    ],
-    "readme": "See README.MD file"
+    ]
 }


### PR DESCRIPTION
Removes field "readme" in package.json because when this field is defined, then npm doesn't show documentation of the package

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/powerbi-visuals/404)
<!-- Reviewable:end -->
