### PR TITLE
Update Typings.md

### DIFF
--- a/Tutorial/Typings.md
+++ b/Tutorial/Typings.md
@@ -18,7 +18,7 @@ To have types for a specific library, run the following command.
 
 ```
 // install d3 typings 
-typings install --save --global dt~d3
+typings install d3=github:DefinitelyTyped/DefinitelyTyped/d3/d3.d.ts#7d3a939fbe55576fad2e074d007f7cc671aa0e78 --source dt --global
 ```
 
 You should now have a typings directory in your visual project.


### PR DESCRIPTION
From https://blogs.msdn.microsoft.com/tsmatsuz/2016/09/27/power-bi-custom-visuals-programming/

Now d3 version 4 is released and compatible for typescript 2.0 (not compatible for typescript 1.8.x). Because pbiviz (visual tools) is now still using typescript 1.8.x, then you must specify d3 old version (commit# 7d3a939fbe55576fad2e074d007f7cc671aa0e78) which is compatible for typescript 1.8.x, instead of "typings install d3 --source dt --global" (Described on Dec 2016)