### PR TITLE
Added Docs for installing d3 v5. Better docs for importing other JS Libraries.

### DIFF
--- a/Tutorial/@Types.md
+++ b/Tutorial/@Types.md
@@ -8,11 +8,11 @@ See [commit](https://github.com/Microsoft/PowerBI-visuals-sampleBarChart/commit/
 For more in depth details about @types, visit the package page on npm. [@types Documentation](https://www.npmjs.com/~types)
 
 ## Add Typings to your Project
-To install types for d3 at version 3.5 (the most recent version supported by pbiviz) as a dev dependency, run the following command.
+To install types for d3 at version 5.x as a dev dependency, run the following command.
 
 ```
 // install d3 typings 
-npm install @types/d3@3.5 --save-dev
+npm install @types/d3@5 --save-dev
 ```
 
 You should now have an @types directory in your node modules.

--- a/Tutorial/ExternalLibraries.md
+++ b/Tutorial/ExternalLibraries.md
@@ -6,13 +6,14 @@
 1. Install an external JavaScript library by using any package manager (npm, yarn, etc.)
 2. Include a path of the library to the ```externalJS``` property of the ```pbiviz.json```
 
-Please pay attention to [this](Typings.md) if you'd like to add typings for your JavaScript file to get intellisense and compile time safety on them.
+Please pay attention to [Types](@Types.md) if you'd like to add typings for your JavaScript file to get intellisense and compile time safety on them.
 
 ### Example
 * Installing [d3](https://www.npmjs.com/package/d3) by using [npm](https://www.npmjs.com/)
 
 ```bash
-npm install d3@4.9.1 --save
+npm install d3@5 --save
+npm install @types/d3 --save-dev
 ```
 
 * Including ```d3``` to the ```pbiviz.json```
@@ -24,15 +25,56 @@ npm install d3@4.9.1 --save
   "author": {...},
   "assets": {...},
   "externalJS": [
-    "node_modules/d3/d3.min.js"
+    "node_modules/d3/dist/d3.min.js"
   ],
   "style": ...,
   "capabilities": ...,
   "dependencies": ...
 }
 ```
+> Note: Please make sure the d3.min.js is indeed in the path that you specify in the `externalJS` property. For example, d3 publisher changed the build directory name from `build` to `dist` during v4 to v5 upgrade.
 
-Please visit [this](https://github.com/Microsoft/powerbi-visuals-sankey/blob/c8200da56913cd8b253be949a35fad0f4472b6de/pbiviz.json#L22) page to find the real example.
+* Accessing the d3 object
+
+To access the d3 object exposed by UMD, you have to explicitly access it through the `window` object.  Like this:
+
+```ts
+// visual.ts
+
+module powerbi.extensibility.visual {
+  export class Visual {
+    ...
+    constructor () {
+      const d3 = window.d3 // <-- accessing d3
+    }
+  }
+}
+```
+
+* Adding Types to d3
+
+When you do this, however, Typescript does not know the type of `d3` on the window object.  You can declare the type like so:
+
+```ts
+interface Window {
+  d3: typeof d3; //<-- declaring the type like so
+}
+
+module powerbi.extensibility.visual {
+  ...
+}
+```
+
+## 
+Please visit [this repo to find the real example](https://github.com/Microsoft/powerbi-visuals-sankey/blob/c8200da56913cd8b253be949a35fad0f4472b6de/pbiviz.json#L22) page .
+
+## Additional notes on including JS Libraries
+There are some things to watch out for when including other JS Libraries.
+* The library has to have UMD enabled.  Meaning it has to add a predefined variable to the global variable (`window`). Otherwise, you'd need to create a wrapper library to expose the library yourself and publish to npm.
+* The library needs to be targeting the browser, not NodeJS.  i.e. `express` cannot be included.
+* The library should not make external HTTP calls.  This is because in order for your visual to be certified, custom visuals cannot make external HTTP calls.
+
+If the JS library uses UMD, then you should be able to follow the similar installation path as d3.
 
 ## Including CSS files
 1. Install an external CSS framework by using any package manager (npm, yarn, etc.)

--- a/Tutorial/ExternalLibraries.md
+++ b/Tutorial/ExternalLibraries.md
@@ -74,7 +74,7 @@ There are some things to watch out for when including other JS Libraries.
 * The library needs to be targeting the browser, not NodeJS.  i.e. `express` cannot be included.
 * The library should not make external HTTP calls.  This is because in order for your visual to be certified, custom visuals cannot make external HTTP calls.
 
-If the JS library uses UMD, then you should be able to follow the similar installation path as d3.
+If the JS library uses UMD, then you should be able to follow similar installation steps as d3.
 
 ## Including CSS files
 1. Install an external CSS framework by using any package manager (npm, yarn, etc.)


### PR DESCRIPTION
This is the full solution for installing d3 version 5 as well as including types.  
[See related issue and answer](https://github.com/Microsoft/PowerBI-visuals/issues/142#issuecomment-381160269)

Additional edits:
* Changed `this` links to be more descriptive to improve accessibility 
* Corrected Types link (broken before)
* Changed `@types.md` to match the information on this page
* [Fixed the `externalJS` path](https://github.com/Microsoft/PowerBI-visuals/issues/98#issuecomment-327749253), and upgraded it to v5 path

Related Issues: #142 #98 #217 